### PR TITLE
fixed url() method typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ $response->success
 
 ### Public url
 
-To generate image url locally call method `url(` and pass image ID. Don't forget to set up
+To generate image url locally call method `url($id)` and pass image ID. Don't forget to set up
 
 ```dotenv
 CLOUDFLARE_IMAGES_DELIVERY_URL=


### PR DESCRIPTION
## Changelog

### Fixed
- typo when referencing `url(` -> `url($id)` method in the public URL section of the readme